### PR TITLE
Add registration number to credit memo

### DIFF
--- a/Plugin/Pdf/Creditmemo.php
+++ b/Plugin/Pdf/Creditmemo.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * This file is part of the Japanese Consumption Tax Extension For Magento2 project.
+ *
+ * Copyright (c) 2023 Adobe (or other copyright holders)
+ *
+ * For the full copyright and license information, please view the OSL-3.0
+ * license that is bundled with this source code in the file LICENSE, or
+ * at https://opensource.org/licenses/OSL-3.0
+ */
+namespace Magentoj\JapaneseConsumptionTax\Plugin\Pdf;
+
+use Magento\Store\Model\ScopeInterface;
+
+class Creditmemo extends \Magento\Sales\Model\Order\Pdf\Creditmemo
+{
+    /**
+     * @var \Magento\Store\Model\App\Emulation
+     */
+    private $appEmulation;
+
+    /**
+     * @var \Magentoj\JapaneseConsumptionTax\Model\Config\JctSystemConfig
+     */
+    private $jctConfig;
+
+    public function __construct(
+        \Magento\Payment\Helper\Data $paymentData,
+        \Magento\Framework\Stdlib\StringUtils $string,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Sales\Model\Order\Pdf\Config $pdfConfig,
+        \Magento\Sales\Model\Order\Pdf\Total\Factory $pdfTotalFactory,
+        \Magento\Sales\Model\Order\Pdf\ItemsFactory $pdfItemsFactory,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
+        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
+        \Magento\Sales\Model\Order\Address\Renderer $addressRenderer,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Store\Model\App\Emulation $appEmulation,
+        \Magentoj\JapaneseConsumptionTax\Model\Config\JctSystemConfig $jctConfig,
+        array $data = []
+    ) {
+        $this->appEmulation = $appEmulation;
+        $this->jctConfig = $jctConfig;
+        parent::__construct(
+            $paymentData,
+            $string,
+            $scopeConfig,
+            $filesystem,
+            $pdfConfig,
+            $pdfTotalFactory,
+            $pdfItemsFactory,
+            $localeDate,
+            $inlineTranslation,
+            $addressRenderer,
+            $storeManager,
+            $appEmulation,
+            $data
+        );
+    }
+
+    public function insertRegistrationNumber(\Zend_Pdf_Page $page, $number)
+    {
+        if (!$number) {
+            return;
+        }
+
+        $page->setFillColor(new \Zend_Pdf_Color_GrayScale(0));
+        $font = $this->_setFontRegular($page, 10);
+        $this->y = $this->y ?: 815;
+        $top = $this->y;
+
+        $font = $this->_setFontRegular($page, 10);
+        $text = __('Registration # ') . trim($number);
+        $page->drawText(
+            $text,
+            $this->getAlignRight($text, 130, 440, $font, 10),
+            $top,
+            'UTF-8'
+        );
+
+        $top -= 10;
+        $this->y = $this->y > $top ? $top : $this->y;
+    }
+
+    public function aroundGetPdf(
+        \Magento\Sales\Model\Order\Pdf\Creditmemo $subject,
+        callable $proceed,
+        array $creditmemos = [],
+    ) {
+        $this->_beforeGetPdf();
+        $this->_initRenderer('creditmemo');
+
+        $pdf = new \Zend_Pdf();
+        $this->_setPdf($pdf);
+        $style = new \Zend_Pdf_Style();
+        $this->_setFontBold($style, 10);
+
+        foreach ($creditmemos as $creditmemo) {
+            if ($creditmemo->getStoreId()) {
+                $this->appEmulation->startEnvironmentEmulation(
+                    $creditmemo->getStoreId(),
+                    \Magento\Framework\App\Area::AREA_FRONTEND,
+                    true
+                );
+                $this->_storeManager->setCurrentStore($creditmemo->getStoreId());
+            }
+            $page = $this->newPage();
+            $order = $creditmemo->getOrder();
+            /* Add image */
+            $this->insertLogo($page, $creditmemo->getStore());
+            /* Add address */
+            $this->insertAddress($page, $creditmemo->getStore());
+            /* Add Japanese tax registration number */
+            $this->insertRegistrationNumber($page, $this->jctConfig->getRegistrationNumber($order->getStoreId()));
+            /* Add head */
+            $this->insertOrder(
+                $page,
+                $order,
+                $this->_scopeConfig->isSetFlag(
+                    self::XML_PATH_SALES_PDF_CREDITMEMO_PUT_ORDER_ID,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                    $order->getStoreId()
+                )
+            );
+            /* Add document text and number */
+            $this->insertDocumentNumber($page, __('Credit Memo # ') . $creditmemo->getIncrementId());
+            /* Add table head */
+            $this->_drawHeader($page);
+            /* Add body */
+            foreach ($creditmemo->getAllItems() as $item) {
+                if ($item->getOrderItem()->getParentItem()) {
+                    continue;
+                }
+                /* Draw item */
+                $this->_drawItem($item, $page, $order);
+                $page = end($pdf->pages);
+            }
+            /* Add totals */
+            $this->insertTotals($page, $creditmemo);
+            if ($creditmemo->getStoreId()) {
+                $this->appEmulation->stopEnvironmentEmulation();
+            }
+        }
+        $this->_afterGetPdf();
+        return $pdf;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -36,6 +36,9 @@
     <type name="\Magento\Sales\Model\Order\Pdf\Invoice">
         <plugin name="magentoj_jct_pdf_invoice" type="Magentoj\JapaneseConsumptionTax\Plugin\Pdf\Invoice" />
     </type>
+    <type name="\Magento\Sales\Model\Order\Pdf\Creditmemo">
+        <plugin name="magentoj_jct_pdf_creditmemo" type="Magentoj\JapaneseConsumptionTax\Plugin\Pdf\Creditmemo" />
+    </type>
     <type name="Magento\Tax\Model\TaxConfigProvider">
         <plugin name="magentoj_jct_config_provider" type="Magentoj\JapaneseConsumptionTax\Plugin\TaxConfigProvider" />
     </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added a registration number to PDF credit memo as it is required in the qualified credit invoices (適格返還請求書) by the JCT law. 


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make sure that the registration number is configured in the configuration
2. Create a credit memo from any invoice
4. Go to the credit memo page and click on the Print button to generate the PDF
5. Confirm the registration number is shown on the top right

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
